### PR TITLE
Initial etckeeper formula for version control of /etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+Current:
+
+* basic etckeeper/git management. Requires bootstrap-formula for git.
+

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,22 @@
+=======
+etckeeper
+=======
+
+Formula to set up and configure 'etckeeper' on a server.
+
+Etckeeper is a simple wrapper around a version control system - Git in this
+case - to keep an historical record of /etc changes.
+
+There is no daemon process, it essentially hooks into package installation and
+cron to periodically commit the state of the /etc directory.
+
+Dependencies
+============
+
+.. note::
+
+   This formula has a dependency on the following salt formulas:
+
+   `bootstrap <https://github.com/ministryofjustice/bootstrap-formula>`_ -- for
+   git
+

--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,12 @@ cron to periodically commit the state of the /etc directory.
 Note that this will store the Git DB at /etc/.git, and as such will increase
 the size of your root filesystem over time.
 
-Dependencies
-============
+NOTE
+----
 
-.. note::
+This also adds 'order: 0' and 'order: last' hooks, which commit at the start
+and end of the Salt run. These pick up any changes made *prior* to the salt run
+and during the salt run.
 
-   This formula has a dependency on the following salt formulas:
-
-   `bootstrap <https://github.com/ministryofjustice/bootstrap-formula>`_ -- for
-   git
-
+These are hash-tagged '#salt-start' and '#salt-end' for subsequent use in
+monitoring scripts.

--- a/README.rst
+++ b/README.rst
@@ -20,5 +20,8 @@ This also adds 'order: 0' and 'order: last' hooks, which commit at the start
 and end of the Salt run. These pick up any changes made *prior* to the salt run
 and during the salt run.
 
+As a result, be careful with any other states that run with 'order: 0' or
+'order: last' -- specifically if they potentially change any files in /etc.
+
 These are hash-tagged '#salt-start' and '#salt-end' for subsequent use in
 monitoring scripts.

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,9 @@ case - to keep an historical record of /etc changes.
 There is no daemon process, it essentially hooks into package installation and
 cron to periodically commit the state of the /etc directory.
 
+Note that this will store the Git DB at /etc/.git, and as such will increase
+the size of your root filesystem over time.
+
 Dependencies
 ============
 

--- a/etckeeper/deps.sls
+++ b/etckeeper/deps.sls
@@ -1,0 +1,5 @@
+etckeeper_deps:
+  pkg.installed:
+    - pkgs:
+      - git
+

--- a/etckeeper/files/etckeeper.conf
+++ b/etckeeper/files/etckeeper.conf
@@ -1,0 +1,25 @@
+VCS="git"
+
+# Options passed to git commit when run by etckeeper.
+GIT_COMMIT_OPTIONS=""
+
+# Uncomment to avoid etckeeper committing existing changes
+# to /etc automatically once per day.
+#AVOID_DAILY_AUTOCOMMITS=1
+
+# Uncomment the following to avoid special file warning
+# (the option is enabled automatically by cronjob regardless).
+#AVOID_SPECIAL_FILE_WARNING=1
+
+# Uncomment to avoid etckeeper committing existing changes to
+# /etc before installation. It will cancel the installation,
+# so you can commit the changes by hand.
+#AVOID_COMMIT_BEFORE_INSTALL=1
+
+# The high-level package manager that's being used.
+# (apt, pacman-g2, yum etc)
+HIGHLEVEL_PACKAGE_MANAGER=apt
+
+# The low-level package manager that's being used.
+# (dpkg, rpm, pacman-g2, etc)
+LOWLEVEL_PACKAGE_MANAGER=dpkg

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -1,11 +1,11 @@
 include:
-  - bootstrap
+  - .deps
 
 etckeeper:
   pkg:
     - installed
     - require:
-      - pkg: git
+      - pkg: etckeeper_deps
   file.managed:
     - name: /etc/etckeeper/etckeeper.conf
     - source: salt://minions/base/files/etckeeper.conf

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -2,13 +2,16 @@ include:
   - bootstrap
 
 etckeeper:
+
   pkg:
     - installed
     - require:
       - pkg: git
+
   file.managed:
     - name: /etc/etckeeper/etckeeper.conf
     - source: salt://minions/base/files/etckeeper.conf
+
   cmd:
     - run
     - cwd: /etc
@@ -17,4 +20,18 @@ etckeeper:
       - pkg: etckeeper
       - file: /etc/etckeeper/etckeeper.conf
     - unless: test -d /etc/.git
+
+  cmd:
+    - run
+    - order: 0
+    - cwd: /etc
+    - name: "/usr/bin/etckeeper commit 'Start of Salt Run'"
+    - onlyif: test -d /etc/.git
+
+  cmd:
+    - run
+    - order: last
+    - cwd: /etc
+    - name: "/usr/bin/etckeeper commit 'End of Salt Run'"
+    - onlyif: test -d /etc/.git
 

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -23,13 +23,13 @@ etckeeper_commit_at_start:
   cmd.run:
     - order: 0
     - cwd: /etc
-    - name: "/usr/bin/etckeeper commit 'Start of Salt Run'"
-    - onlyif: test -d /etc/.git
+    - name: 'if [ -n "$(git status --porcelain)" ]; then /usr/bin/etckeeper commit "Changes found prior to start of salt run #salt-start"; fi'
+    - onlyif: 'test -d /etc/.git && test -n "$(git status --porcelain)"'
 
 etckeeper_commit_at_end:
   cmd.run:
     - order: last
     - cwd: /etc
-    - name: "/usr/bin/etckeeper commit 'End of Salt Run'"
-    - onlyif: test -d /etc/.git
+    - name: '/usr/bin/etckeeper commit "Changes made during salt run #salt-end"'
+    - onlyif: 'test -d /etc/.git && test -n "$(git status --porcelain)"'
 

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -8,7 +8,7 @@ etckeeper:
       - pkg: etckeeper_deps
   file.managed:
     - name: /etc/etckeeper/etckeeper.conf
-    - source: salt://minions/base/files/etckeeper.conf
+    - source: salt://etckeeper/files/etckeeper.conf
 
 etckeeper_initial_commit:
   cmd.run:

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -2,18 +2,16 @@ include:
   - bootstrap
 
 etckeeper:
-
   pkg:
     - installed
     - require:
       - pkg: git
-
   file.managed:
     - name: /etc/etckeeper/etckeeper.conf
     - source: salt://minions/base/files/etckeeper.conf
 
-  cmd:
-    - run
+etckeeper_initial_commit:
+  cmd.run:
     - cwd: /etc
     - name: "/usr/bin/etckeeper init && /usr/bin/etckeeper commit 'Initial commit'"
     - require:
@@ -21,15 +19,15 @@ etckeeper:
       - file: /etc/etckeeper/etckeeper.conf
     - unless: test -d /etc/.git
 
-  cmd:
-    - run
+etckeeper_commit_at_start:
+  cmd.run:
     - order: 0
     - cwd: /etc
     - name: "/usr/bin/etckeeper commit 'Start of Salt Run'"
     - onlyif: test -d /etc/.git
 
-  cmd:
-    - run
+etckeeper_commit_at_end:
+  cmd.run:
     - order: last
     - cwd: /etc
     - name: "/usr/bin/etckeeper commit 'End of Salt Run'"

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -23,7 +23,7 @@ etckeeper_commit_at_start:
   cmd.run:
     - order: 0
     - cwd: /etc
-    - name: 'if [ -n "$(git status --porcelain)" ]; then /usr/bin/etckeeper commit "Changes found prior to start of salt run #salt-start"; fi'
+    - name: '/usr/bin/etckeeper commit "Changes found prior to start of salt run #salt-start"'
     - onlyif: 'test -d /etc/.git && test -n "$(git status --porcelain)"'
 
 etckeeper_commit_at_end:

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -1,0 +1,20 @@
+include:
+  - bootstrap
+
+etckeeper:
+  pkg:
+    - installed
+    - require:
+      - pkg: git
+  file.managed:
+    - name: /etc/etckeeper/etckeeper.conf
+    - source: salt://minions/base/files/etckeeper.conf
+  cmd:
+    - run
+    - cwd: /etc
+    - name: "/usr/bin/etckeeper init && /usr/bin/etckeeper commit 'Initial commit'"
+    - require:
+      - pkg: etckeeper
+      - file: /etc/etckeeper/etckeeper.conf
+    - unless: test -d /etc/.git
+

--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -1,0 +1,1 @@
+git@github.com:ministryofjustice/bootstrap-formula.git==v1.0.1

--- a/formula-requirements.txt
+++ b/formula-requirements.txt
@@ -1,1 +1,0 @@
-git@github.com:ministryofjustice/bootstrap-formula.git==v1.0.1


### PR DESCRIPTION
etckeeper is a simple wrapper around a VCS - git in our case - which keeps track of changes to the /etc dir.

This formula adds the etckeeper package, configures it to use Git, and initialises the repo.

The default package setup runs a commit after each package installation, and also one per day via cron.

This also adds hooks to Salt to commit at the start and end (via order:0 and order:last), to ensure changed made before and by Salt are recorded.
