### PR TITLE
Implement clean-dir workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-1.0.0:
+v1.0.1:
+
+* Fix cleaning of dirs so that they do not always flag as changed.
+
+v1.0.0:
 
 * highlight package install operation performed under salt
 * hard-manage all /etc/etckeeper directories, to prevent manual disabling

--- a/etckeeper/init.sls
+++ b/etckeeper/init.sls
@@ -19,8 +19,13 @@ etckeeper:
   file.managed:
     - source: salt://etckeeper/files/etckeeper.conf
     - mode: 0644
+    - makedirs: True
     - owner: root
     - group: root
+    - require_in:
+      - file: /etc/etckeeper
+    - require:
+      - pkg: etckeeper
 
 {% set subdirs = [
     'pre-install.d',
@@ -43,11 +48,14 @@ etckeeper:
     - clean: True
     - dir_mode: 0755
     - file_mode: 0755
+    - makedirs: True
     - exclude_pat: README
     - owner: root
     - group: root
     - require:
        - pkg: etckeeper
+    - require_in:
+       - file: /etc/etckeeper
 {% endfor %}
 
 etckeeper_initial_commit:


### PR DESCRIPTION
This weird ordering ensures that directories marked Clean do not clean up
files 'required' by them even though this is backwards logic. The 'makedirs' handles
the need to have the directory created beforehand.
